### PR TITLE
Add Trash Post Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Trashed blog posts are now deleted from the search results (PR #8)
+
 ### Security
 - Updating dependencies to fix vulnerabilities in symfony/cache and symfony/var-exporter (PR #7)
 

--- a/includes/class-ed-solr.php
+++ b/includes/class-ed-solr.php
@@ -179,6 +179,7 @@ class Ed_Solr {
 		$this->loader->add_action( 'publish_post', $plugin_public, 'store_post' );
 		$this->loader->add_action( 'publish_page', $plugin_public, 'store_post' );
 		$this->loader->add_action( 'delete_post', $plugin_public, 'delete_post' );
+		$this->loader->add_action( 'wp_trash_post', $plugin_public, 'delete_post' );
 	}
 
 	/**


### PR DESCRIPTION
At the moment, if a user deletes a post, it still shows in the search results because we only remove it from the Solr index if it has been deleted. WordPress does not class posts as deleted until they are permanently deleted from the bin.

This PR adds a hook to remove a post from the Solr instance as soon as it is _trashed_.