### PR TITLE
Fix arguments for get_posts()

### DIFF
--- a/includes/class-ed-solr-index-blogs-cli.php
+++ b/includes/class-ed-solr-index-blogs-cli.php
@@ -8,8 +8,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	class Ed_Solr_Index_Blogs_CLI extends WP_CLI_Command {
 
 		public const NO_OF_BLOGS_PER_BATCH = 100;
-		public const ALL_POSTS = - 1;
-		public const MAX_NUMBER_OF_BLOGS = '200000';
+		public const ALL_POSTS             = -1;
+		public const MAX_NUMBER_OF_BLOGS   = '200000';
 
 		/**
 		 * Index all blogs in a WordPress instance into Apache Solr through WP CLI command.
@@ -42,7 +42,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			foreach ( $blogs as $blog ) {
 				switch_to_blog( $blog->blog_id );
 
-				$posts = get_posts( self::ALL_POSTS );
+				$posts = get_posts( array( 'numberposts' => self::ALL_POSTS ) );
 
 				foreach ( $posts as $post ) {
 					if ( 'publish' === $post->post_status ) {
@@ -56,11 +56,11 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 			$to      = get_site_option( 'solr-email' );
 			$subject = 'ED BLOGS: background indexing process ended.';
-			$message = '<p>The background indexing process has finished.</p><p>Status message: ' . ( $status === 0 ? 'All good' : 'Something was not right  (' . $status . ')' ) . '<p><p>Thank you.</p>';
+			$message = '<p>The background indexing process has finished.</p><p>Status message: ' . ( 0 === $status ? 'All good' : 'Something was not right  (' . $status . ')' ) . '<p><p>Thank you.</p>';
 			$headers = array( 'Content-Type: text/html; charset=UTF-8' );
 
 			if ( ! wp_mail( $to, $subject, $message, $headers ) ) {
-				error_log( 'Could not send background index process ended email.');
+				error_log( 'Could not send background index process ended email.' );
 			}
 
 			exit;


### PR DESCRIPTION
This PR fixes the number of posts we can retrieve using `get_posts()`. The function expects an array as an argument but we were originally passing in an integer. 